### PR TITLE
Fixes for LegacyTagsManager and SkeletonGenerator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "composer/composer": "^1.6.0 || ^1.7.0",
         "mockery/mockery": "^1.0.0",
-        "narrowspark/coding-standard": "^1.1.2",
+        "narrowspark/coding-standard": "^1.2.0",
         "narrowspark/testing-helper": "^7.0.0",
         "nyholm/nsa": "^1.1.0",
         "phpunit/phpunit": "^7.2.0",

--- a/src/Automatic/AbstractConfigurator.php
+++ b/src/Automatic/AbstractConfigurator.php
@@ -53,6 +53,16 @@ abstract class AbstractConfigurator
     }
 
     /**
+     * Get all registered configurators.
+     *
+     * @return array
+     */
+    public function getConfigurators(): array
+    {
+        return $this->configurators;
+    }
+
+    /**
      * Add a new automatic configurator.
      *
      * @param string $name
@@ -117,16 +127,6 @@ abstract class AbstractConfigurator
                 $this->get($key)->unconfigure($package);
             }
         }
-    }
-
-    /**
-     * Get all registered configurators.
-     *
-     * @return array
-     */
-    public function getConfigurators(): array
-    {
-        return $this->configurators;
     }
 
     public function reset(): void

--- a/src/Automatic/ClassFinder.php
+++ b/src/Automatic/ClassFinder.php
@@ -80,6 +80,74 @@ final class ClassFinder implements ResettableContract
     }
 
     /**
+     * Returns a list with found traits.
+     *
+     * @return array|string[]
+     */
+    public function getTraits(): array
+    {
+        return $this->traits;
+    }
+
+    /**
+     * Returns a list with found interfaces.
+     *
+     * @return array|string[]
+     */
+    public function getInterfaces(): array
+    {
+        return $this->interfaces;
+    }
+
+    /**
+     * Returns a list with found abstract classes.
+     *
+     * @return array|string[]
+     */
+    public function getAbstractClasses(): array
+    {
+        return $this->abstractClasses;
+    }
+
+    /**
+     * Returns a list with found classes.
+     *
+     * @return array|string[]
+     */
+    public function getClasses(): array
+    {
+        return $this->classes;
+    }
+
+    /**
+     * Exclude paths from finder.
+     *
+     * @param array $excludes
+     *
+     * @return \Narrowspark\Automatic\ClassFinder
+     */
+    public function setExcludes(array $excludes): self
+    {
+        $this->excludes = $excludes;
+
+        return $this;
+    }
+
+    /**
+     * Set a symfony finder filter.
+     *
+     * @param \Closure $filter
+     *
+     * @return \Narrowspark\Automatic\ClassFinder
+     */
+    public function setFilter(Closure $filter): self
+    {
+        $this->filter = $filter;
+
+        return $this;
+    }
+
+    /**
      * Set the composer.json file autoload key values.
      *
      * @param string $packageName
@@ -156,34 +224,6 @@ final class ClassFinder implements ResettableContract
     }
 
     /**
-     * Exclude paths from finder.
-     *
-     * @param array $excludes
-     *
-     * @return \Narrowspark\Automatic\ClassFinder
-     */
-    public function setExcludes(array $excludes): self
-    {
-        $this->excludes = $excludes;
-
-        return $this;
-    }
-
-    /**
-     * Set a symfony finder filter.
-     *
-     * @param \Closure $filter
-     *
-     * @return \Narrowspark\Automatic\ClassFinder
-     */
-    public function setFilter(Closure $filter): self
-    {
-        $this->filter = $filter;
-
-        return $this;
-    }
-
-    /**
      * Find all the class, traits and interface names in a given directory.
      *
      * @return \Narrowspark\Automatic\ClassFinder
@@ -240,46 +280,6 @@ final class ClassFinder implements ResettableContract
         }
 
         return $this;
-    }
-
-    /**
-     * Returns a list with found abstract classes.
-     *
-     * @return array|string[]
-     */
-    public function getAbstractClasses(): array
-    {
-        return $this->abstractClasses;
-    }
-
-    /**
-     * Returns a list with found classes.
-     *
-     * @return array|string[]
-     */
-    public function getClasses(): array
-    {
-        return $this->classes;
-    }
-
-    /**
-     * Returns a list with found interfaces.
-     *
-     * @return array|string[]
-     */
-    public function getInterfaces(): array
-    {
-        return $this->interfaces;
-    }
-
-    /**
-     * Returns a list with found traits.
-     *
-     * @return array|string[]
-     */
-    public function getTraits(): array
-    {
-        return $this->traits;
     }
 
     /**

--- a/src/Automatic/Installer/AbstractInstaller.php
+++ b/src/Automatic/Installer/AbstractInstaller.php
@@ -92,8 +92,11 @@ abstract class AbstractInstaller extends LibraryInstaller
     /**
      * {@inheritdoc}
      */
-    public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target): void
-    {
+    public function update(
+        InstalledRepositoryInterface $repo,
+        PackageInterface $initial,
+        PackageInterface $target
+    ): void {
         parent::update($repo, $initial, $target);
 
         $this->saveToLockFile($target->getAutoload(), $target, static::LOCK_KEY);

--- a/src/Automatic/Prefetcher/ParallelDownloader.php
+++ b/src/Automatic/Prefetcher/ParallelDownloader.php
@@ -122,6 +122,28 @@ class ParallelDownloader extends RemoteFilesystem
     }
 
     /**
+     * Set the next options for the remote filesystem.
+     *
+     * @param array $options
+     *
+     * @return $this
+     */
+    public function setNextOptions(array $options): self
+    {
+        $this->nextOptions = parent::getOptions() !== $options ? $options : [];
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLastHeaders(): ?array
+    {
+        return $this->lastHeaders ?? parent::getLastHeaders();
+    }
+
+    /**
      * Parallel download for providers.
      *
      * @param array    $nextArgs
@@ -197,28 +219,6 @@ class ParallelDownloader extends RemoteFilesystem
     }
 
     /**
-     * Set the next options for the remote filesystem.
-     *
-     * @param array $options
-     *
-     * @return $this
-     */
-    public function setNextOptions(array $options): self
-    {
-        $this->nextOptions = parent::getOptions() !== $options ? $options : [];
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getLastHeaders(): ?array
-    {
-        return $this->lastHeaders ?? parent::getLastHeaders();
-    }
-
-    /**
      * Copy the remote file in local.
      *
      * @param string      $originUrl The origin URL
@@ -231,8 +231,13 @@ class ParallelDownloader extends RemoteFilesystem
      *
      * @return bool|string
      */
-    public function copy($originUrl, $fileUrl, $fileName, $progress = true, $options = [])
-    {
+    public function copy(
+        $originUrl,
+        $fileUrl,
+        $fileName,
+        $progress = true,
+        $options  = []
+    ) {
         $options           = \array_replace_recursive($this->nextOptions, $options);
         $this->nextOptions = [];
         $rfs               = clone $this;
@@ -260,8 +265,15 @@ class ParallelDownloader extends RemoteFilesystem
      *
      * @internal
      */
-    public function callbackGet($notificationCode, $severity, $message, $messageCode, $bytesTransferred, $bytesMax, $nativeDownload = true): void
-    {
+    public function callbackGet(
+        $notificationCode,
+        $severity,
+        $message,
+        $messageCode,
+        $bytesTransferred,
+        $bytesMax,
+        $nativeDownload = true
+    ): void {
         if (! $nativeDownload && \STREAM_NOTIFY_SEVERITY_ERR === $severity) {
             throw new TransportException($message, $messageCode);
         }

--- a/src/Automatic/Prefetcher/Prefetcher.php
+++ b/src/Automatic/Prefetcher/Prefetcher.php
@@ -140,6 +140,7 @@ class Prefetcher
                 if (! isset($repo['type']) || $repo['type'] !== 'composer' || ! empty($repo['force-lazy-providers'])) {
                     continue;
                 }
+
                 /** @see https://github.com/composer/composer/blob/master/src/Composer/Repository/ComposerRepository.php#L74 */
                 if (! \preg_match('#^http(s\??)?://#', $repo['url'])) {
                     continue;

--- a/src/Automatic/Prefetcher/TruncatedComposerRepository.php
+++ b/src/Automatic/Prefetcher/TruncatedComposerRepository.php
@@ -21,8 +21,13 @@ class TruncatedComposerRepository extends BaseComposerRepository
     /**
      * {@inheritdoc}
      */
-    public function __construct(array $repoConfig, IOInterface $io, Config $config, EventDispatcher $eventDispatcher = null, RemoteFilesystem $rfs = null)
-    {
+    public function __construct(
+        array $repoConfig,
+        IOInterface $io,
+        Config $config,
+        EventDispatcher $eventDispatcher = null,
+        RemoteFilesystem $rfs            = null
+    ) {
         parent::__construct($repoConfig, $io, $config, $eventDispatcher, $rfs);
 
         $this->cache = new Cache(

--- a/src/Automatic/QuestionFactory.php
+++ b/src/Automatic/QuestionFactory.php
@@ -50,7 +50,7 @@ PHP;
         $value = \mb_strtolower($value[0]);
 
         if (! \in_array($value, ['y', 'n', 'a', 'p'], true)) {
-            throw new InvalidArgumentException('Invalid choice');
+            throw new InvalidArgumentException('Invalid choice.');
         }
 
         return $value;

--- a/src/Automatic/ScriptExecutor.php
+++ b/src/Automatic/ScriptExecutor.php
@@ -61,12 +61,8 @@ final class ScriptExecutor
      * @param \Composer\Util\ProcessExecutor $executor
      * @param array                          $options
      */
-    public function __construct(
-        Composer $composer,
-        IOInterface $io,
-        ProcessExecutor $executor,
-        array $options
-    ) {
+    public function __construct(Composer $composer, IOInterface $io, ProcessExecutor $executor, array $options)
+    {
         $this->composer = $composer;
         $this->io       = $io;
         $this->executor = $executor;

--- a/src/Common/Installer/Installer.php
+++ b/src/Common/Installer/Installer.php
@@ -5,6 +5,7 @@ namespace Narrowspark\Automatic\Common\Installer;
 use Composer\Composer;
 use Composer\Config;
 use Composer\Installer as BaseInstaller;
+use Composer\Installer\SuggestedPackagesReporter;
 use Composer\IO\IOInterface;
 use Composer\IO\NullIO;
 use Symfony\Component\Console\Input\InputInterface;
@@ -60,9 +61,9 @@ final class Installer
             ->setDryRun(self::getOption($input, 'dry-run'))
             ->setVerbose(self::getOption($input, 'verbose'))
             ->setDevMode(! self::getOption($input, 'no-dev'))
-            ->setSuggestedPackagesReporter(new BaseInstaller\SuggestedPackagesReporter(new NullIO()))
+            ->setSuggestedPackagesReporter(new SuggestedPackagesReporter(new NullIO()))
             ->setDumpAutoloader(! self::getOption($input, 'no-autoloader'))
-//            ->setRunScripts(! self::getOption($input, 'no-scripts'))
+            ->setRunScripts(! self::getOption($input, 'no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu)

--- a/src/Common/Installer/Installer.php
+++ b/src/Common/Installer/Installer.php
@@ -6,6 +6,7 @@ use Composer\Composer;
 use Composer\Config;
 use Composer\Installer as BaseInstaller;
 use Composer\IO\IOInterface;
+use Composer\IO\NullIO;
 use Symfony\Component\Console\Input\InputInterface;
 
 /**
@@ -33,8 +34,18 @@ final class Installer
      */
     public static function create(IOInterface $io, Composer $composer, InputInterface $input): BaseInstaller
     {
-        $installer = BaseInstaller::create($io, $composer);
         $config    = $composer->getConfig();
+        $installer = new BaseInstaller(
+            $io,
+            $config,
+            $composer->getPackage(),
+            $composer->getDownloadManager(),
+            $composer->getRepositoryManager(),
+            $composer->getLocker(),
+            $composer->getInstallationManager(),
+            $composer->getEventDispatcher(),
+            $composer->getAutoloadGenerator()
+        );
 
         [$preferSource, $preferDist] = self::getPreferredInstallOptions($config, $input);
 
@@ -49,9 +60,9 @@ final class Installer
             ->setDryRun(self::getOption($input, 'dry-run'))
             ->setVerbose(self::getOption($input, 'verbose'))
             ->setDevMode(! self::getOption($input, 'no-dev'))
-            ->setSkipSuggest(self::getOption($input, 'no-suggest'))
+            ->setSuggestedPackagesReporter(new BaseInstaller\SuggestedPackagesReporter(new NullIO()))
             ->setDumpAutoloader(! self::getOption($input, 'no-autoloader'))
-            ->setRunScripts(! self::getOption($input, 'no-scripts'))
+//            ->setRunScripts(! self::getOption($input, 'no-scripts'))
             ->setOptimizeAutoloader($optimize)
             ->setClassMapAuthoritative($authoritative)
             ->setApcuAutoloader($apcu)

--- a/src/Common/Package.php
+++ b/src/Common/Package.php
@@ -107,6 +107,166 @@ final class Package implements PackageContract
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setName(string $name): PackageContract
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrettyName(): string
+    {
+        return $this->prettyName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParentName(): ?string
+    {
+        return $this->parentName;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setParentName(string $name): PackageContract
+    {
+        $this->parentName = $name;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPrettyVersion(): ?string
+    {
+        return $this->prettyVersion;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setType(string $type): PackageContract
+    {
+        $this->type = $type;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUrl(): ?string
+    {
+        return $this->url;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setUrl(string $url): PackageContract
+    {
+        $this->url = $url;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOperation(): ?string
+    {
+        return $this->operation;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOperation(string $operation): PackageContract
+    {
+        $this->operation = $operation;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequires(): array
+    {
+        return $this->requires;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setRequires(array $requires): PackageContract
+    {
+        $this->requires = $requires;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getConfigs(): array
+    {
+        return $this->configs;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAutoload(): array
+    {
+        return $this->autoload;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setAutoload(array $autoload): PackageContract
+    {
+        $this->autoload = $autoload;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setIsDev(bool $bool = true): PackageContract
+    {
+        $this->isDev = $bool;
+
+        return $this;
+    }
+
+    /**
      * Create a automatic package from the lock data.
      *
      * @param string $name
@@ -142,161 +302,9 @@ final class Package implements PackageContract
     /**
      * {@inheritdoc}
      */
-    public function setName(string $name): PackageContract
-    {
-        $this->name = $name;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPrettyName(): string
-    {
-        return $this->prettyName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getPrettyVersion(): ?string
-    {
-        return $this->prettyVersion;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setIsDev(bool $bool = true): PackageContract
-    {
-        $this->isDev = $bool;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function isDev(): bool
     {
         return $this->isDev;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setAutoload(array $autoload): PackageContract
-    {
-        $this->autoload = $autoload;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getAutoload(): array
-    {
-        return $this->autoload;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setUrl(string $url): PackageContract
-    {
-        $this->url = $url;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getUrl(): ?string
-    {
-        return $this->url;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setOperation(string $operation): PackageContract
-    {
-        $this->operation = $operation;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getOperation(): ?string
-    {
-        return $this->operation;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setType(string $type): PackageContract
-    {
-        $this->type = $type;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType(): ?string
-    {
-        return $this->type;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setParentName(string $name): PackageContract
-    {
-        $this->parentName = $name;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getParentName(): ?string
-    {
-        return $this->parentName;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setRequires(array $requires): PackageContract
-    {
-        $this->requires = $requires;
-
-        return $this;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getRequires(): array
-    {
-        return $this->requires;
     }
 
     /**
@@ -343,14 +351,6 @@ final class Package implements PackageContract
         }
 
         return null;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getConfigs(): array
-    {
-        return $this->configs;
     }
 
     /**

--- a/tests/Automatic/Fixture/ComposerJsonFactory.php
+++ b/tests/Automatic/Fixture/ComposerJsonFactory.php
@@ -15,10 +15,10 @@ class ComposerJsonFactory
      */
     public static function createComposerJson(
         string $name,
-        array $require = [],
+        array $require    = [],
         array $devRequire = [],
-        array $autoload = [],
-        array $extra = []
+        array $autoload   = [],
+        array $extra      = []
     ): string {
         $composerJsonContent = [
             'name'    => $name,
@@ -48,8 +48,12 @@ class ComposerJsonFactory
      *
      * @return string
      */
-    public static function createAutomaticComposerJson(string $name, array $require = [], array $devRequire = [], array $automaticExtra = []): string
-    {
+    public static function createAutomaticComposerJson(
+        string $name,
+        array $require        = [],
+        array $devRequire     = [],
+        array $automaticExtra = []
+    ): string {
         $extendedExtra = [
             'automatic' => $automaticExtra,
         ];

--- a/tests/Automatic/Fixture/MockedQuestionableInstallationManager.php
+++ b/tests/Automatic/Fixture/MockedQuestionableInstallationManager.php
@@ -12,6 +12,14 @@ class MockedQuestionableInstallationManager extends QuestionableInstallationMana
     private $installer;
 
     /**
+     * {@inheritdoc}
+     */
+    protected function getInstaller(): BaseInstaller
+    {
+        return $this->installer;
+    }
+
+    /**
      * @param object $installer
      */
     public function setInstaller($installer): void
@@ -33,13 +41,5 @@ class MockedQuestionableInstallationManager extends QuestionableInstallationMana
     public function getVersionSelector(): VersionSelector
     {
         return $this->versionSelector;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function getInstaller(): BaseInstaller
-    {
-        return $this->installer;
     }
 }

--- a/tests/Automatic/LegacyTagsManagerTest.php
+++ b/tests/Automatic/LegacyTagsManagerTest.php
@@ -101,4 +101,135 @@ final class LegacyTagsManagerTest extends MockeryTestCase
 
         static::assertNotSame($originalData['packages'], $data['packages']);
     }
+
+    /**
+     * @dataProvider provideRemoveLegacyTags
+     *
+     * @param array  $expected
+     * @param array  $packages
+     * @param string $symfonyRequire
+     *
+     * @return void
+     */
+    public function testRemoveLegacyTags(array $expected, array $packages, string $symfonyRequire): void
+    {
+        $this->tagsManger->addConstraint('symfony/symfony', $symfonyRequire);
+
+        $this->ioMock->shouldReceive('writeError');
+
+        static::assertSame(['packages' => $expected], $this->tagsManger->removeLegacyTags(['packages' => $packages]));
+    }
+
+    /**
+     * @return \Generator
+     */
+    public function provideRemoveLegacyTags(): \Generator
+    {
+        yield 'no-symfony/symfony' => [[123], [123], '~1'];
+
+        $branchAlias = function ($versionAlias) {
+            return [
+                'extra' => [
+                    'branch-alias' => [
+                        'dev-master' => $versionAlias . '-dev',
+                    ],
+                ],
+            ];
+        };
+
+        $packages = [
+            'foo/unrelated' => [
+                '1.0.0' => [],
+            ],
+            'symfony/symfony' => [
+                '3.3.0' => [
+                    'version_normalized' => '3.3.0.0',
+                    'replace'            => ['symfony/foo' => 'self.version'],
+                ],
+                '3.4.0' => [
+                    'version_normalized' => '3.4.0.0',
+                    'replace'            => ['symfony/foo' => 'self.version'],
+                ],
+                'dev-master' => $branchAlias('3.5') + [
+                    'replace' => ['symfony/foo' => 'self.version'],
+                ],
+            ],
+            'symfony/foo' => [
+                '3.3.0'      => ['version_normalized' => '3.3.0.0'],
+                '3.4.0'      => ['version_normalized' => '3.4.0.0'],
+                'dev-master' => $branchAlias('3.5'),
+            ],
+        ];
+
+        yield 'empty-intersection-ignores' => [$packages, $packages, '~2.0'];
+
+        yield 'empty-intersection-ignores' => [$packages, $packages, '~4.0'];
+
+        $expected = $packages;
+
+        unset($expected['symfony/symfony']['3.3.0'], $expected['symfony/foo']['3.3.0']);
+
+        yield 'non-empty-intersection-filters' => [$expected, $packages, '~3.4'];
+
+        unset($expected['symfony/symfony']['3.4.0'], $expected['symfony/foo']['3.4.0']);
+
+        yield 'master-only' => [$expected, $packages, '~3.5'];
+
+        $packages = [
+            'symfony/symfony' => [
+                '2.8.0' => [
+                    'version_normalized' => '2.8.0.0',
+                    'replace'            => [
+                        'symfony/legacy' => 'self.version',
+                        'symfony/foo'    => 'self.version',
+                    ],
+                ],
+            ],
+            'symfony/legacy' => [
+                '2.8.0'      => ['version_normalized' => '2.8.0.0'],
+                'dev-master' => $branchAlias('2.8'),
+            ],
+        ];
+
+        yield 'legacy-are-not-filtered' => [$packages, $packages, '~3.0'];
+
+        $packages = [
+            'symfony/symfony' => [
+                '2.8.0' => [
+                    'version_normalized' => '2.8.0.0',
+                    'replace'            => [
+                        'symfony/foo' => 'self.version',
+                        'symfony/new' => 'self.version',
+                    ],
+                ],
+                'dev-master' => $branchAlias('3.0') + [
+                    'replace' => [
+                        'symfony/foo' => 'self.version',
+                        'symfony/new' => 'self.version',
+                    ],
+                ],
+            ],
+            'symfony/foo' => [
+                '2.8.0'      => ['version_normalized' => '2.8.0.0'],
+                'dev-master' => $branchAlias('3.0'),
+            ],
+            'symfony/new' => [
+                'dev-master' => $branchAlias('3.0'),
+            ],
+        ];
+
+        $expected = $packages;
+
+        unset($expected['symfony/symfony']['dev-master'], $expected['symfony/foo']['dev-master']);
+
+        yield 'master-is-filtered-only-when-in-range' => [$expected, $packages, '~2.8'];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function allowMockingNonExistentMethods(bool $allow = false): void
+    {
+        parent::allowMockingNonExistentMethods(true);
+    }
 }

--- a/tests/Automatic/SkeletonGeneratorTest.php
+++ b/tests/Automatic/SkeletonGeneratorTest.php
@@ -87,14 +87,8 @@ final class SkeletonGeneratorTest extends MockeryTestCase
             ->once();
 
         $this->arrangeLock(
-            [
-                'test/generator' => [
-                    ConsoleFixtureGenerator::class => '%vendor_path%/Fixture/ConsoleFixtureGenerator.php',
-                ],
-            ],
-            [
-                'test/generator' => [ConsoleFixtureGenerator::class],
-            ]
+            [ConsoleFixtureGenerator::class => '%vendor_path%/Fixture/ConsoleFixtureGenerator.php'],
+            ['test/generator' => [ConsoleFixtureGenerator::class]]
         );
 
         $this->ioMock->shouldReceive('select')
@@ -117,14 +111,10 @@ final class SkeletonGeneratorTest extends MockeryTestCase
 
         $this->arrangeLock(
             [
-                'test/generator' => [
-                    ConsoleFixtureGenerator::class          => '%vendor_path%/Fixture/ConsoleFixtureGenerator.php',
-                    FrameworkDefaultFixtureGenerator::class => '%vendor_path%/Fixture/FrameworkDefaultFixtureGenerator.php',
-                ],
+                ConsoleFixtureGenerator::class          => '%vendor_path%/Fixture/ConsoleFixtureGenerator.php',
+                FrameworkDefaultFixtureGenerator::class => '%vendor_path%/Fixture/FrameworkDefaultFixtureGenerator.php',
             ],
-            [
-                'test/generator' => [ConsoleFixtureGenerator::class, FrameworkDefaultFixtureGenerator::class],
-            ]
+            ['test/generator' => [ConsoleFixtureGenerator::class, FrameworkDefaultFixtureGenerator::class]]
         );
 
         $this->ioMock->shouldReceive('select')
@@ -139,27 +129,23 @@ final class SkeletonGeneratorTest extends MockeryTestCase
 
     public function testRemove(): void
     {
-        $this->arrangeLock(
-            [
-                'test/generator' => [
-                    '%vendor_path%/Fixture/ConsoleFixtureGenerator.php',
-                ],
-            ],
-            [
-                'test/generator' => [ConsoleFixtureGenerator::class],
-            ]
-        );
+        $this->lockMock->shouldReceive('get')
+            ->once()
+            ->with(SkeletonInstaller::LOCK_KEY)
+            ->andReturn(['test/generator' => [ConsoleFixtureGenerator::class]]);
 
         $this->installationManagerMock->shouldReceive('uninstall')
             ->once()
             ->with(\Mockery::type('array'), []);
 
+        $this->lockMock->shouldReceive('read')
+            ->once();
+        $this->lockMock->shouldReceive('remove')
+            ->once()
+            ->with(Automatic::LOCK_CLASSMAP, 'test/generator');
         $this->lockMock->shouldReceive('remove')
             ->once()
             ->with(SkeletonInstaller::LOCK_KEY);
-        $this->lockMock->shouldReceive('add')
-            ->once()
-            ->with(Automatic::LOCK_CLASSMAP, []);
         $this->lockMock->shouldReceive('write')
             ->once();
 
@@ -182,7 +168,7 @@ final class SkeletonGeneratorTest extends MockeryTestCase
     {
         $this->lockMock->shouldReceive('get')
             ->once()
-            ->with(Automatic::LOCK_CLASSMAP)
+            ->with(Automatic::LOCK_CLASSMAP, 'test/generator')
             ->andReturn($classmap);
 
         $this->lockMock->shouldReceive('get')

--- a/tests/Common/Installer/InstallerTest.php
+++ b/tests/Common/Installer/InstallerTest.php
@@ -113,10 +113,6 @@ final class InstallerTest extends MockeryTestCase
             ->andReturn(false);
         $this->inputMock->shouldReceive('hasOption')
             ->once()
-            ->with('no-suggest')
-            ->andReturn(false);
-        $this->inputMock->shouldReceive('hasOption')
-            ->once()
             ->with('apcu-autoloader')
             ->andReturn(false);
         $this->inputMock->shouldReceive('hasOption')


### PR DESCRIPTION
fixes don't filter packages that have empty intersection with legacy tags
fixes lock writing in skeleton installer

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -