### PR TITLE
fix: remove deprecated CURLPIPE_HTTP1 support flag

### DIFF
--- a/src/Automatic/Prefetcher/CurlDownloader.php
+++ b/src/Automatic/Prefetcher/CurlDownloader.php
@@ -78,7 +78,7 @@ final class CurlDownloader
     {
         $this->multiHandle = $mh = \curl_multi_init();
 
-        \curl_multi_setopt($mh, \CURLMOPT_PIPELINING, /*CURLPIPE_HTTP1 | CURLPIPE_MULTIPLEX*/ 3);
+        \curl_multi_setopt($mh, \CURLMOPT_PIPELINING, /*CURLPIPE_MULTIPLEX*/ 2);
 
         if (\defined('CURLMOPT_MAX_HOST_CONNECTIONS')) {
             \curl_multi_setopt($mh, \CURLMOPT_MAX_HOST_CONNECTIONS, 10);


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | -
| License         | MIT
| Doc PR          | -